### PR TITLE
updates script param handling

### DIFF
--- a/src/routes/index/+server.js
+++ b/src/routes/index/+server.js
@@ -270,14 +270,32 @@ const handleHTML = async (response, s) => {
 const handler = async (s) => {
   let url = new URL(s)
   let isVerifiedOrigin = await verifiedOrigin(`${url.origin}/`)
-  let isBearBlog = document.head.querySelectorAll('meta').some(metaTag => metaTag.getAttribute('content') === 'look-for-the-bear-necessities')
+
+  const isBearBlog(document){
+    let isGood = document.head.querySelectorAll('meta').some(metaTag => metaTag.getAttribute('content') === 'look-for-the-bear-necessities')
+    let isNotBad = true;
+    const robotsMetaTags = document.querySelectorAll('meta[robots]');
+    for (const robot of robotsMetaTags) {
+      if (robot.getAttribute('robots') === 'noindex' || robot.getAttribute('robots') === 'nofollow') {
+          isNotBad = false;
+      }
+    }
+    if (isGood && isNotBad ) {
+      return true;
+    }
+    else {
+      return false;
+      console.log("Octothorpes will not index this page");
+    }
+   }
+
   if (!isVerifiedOrigin) {
     // adding as second level check so we still have the option to manually register
     // which we might have to do in the case of white/blacklisting if anyone starts spoofing this check
     // in any case, hard-coding this check into the main indexer is obvs not ideal and should be 
     // generalized to an extendable from of altVerification
-    
-    if (!isBearBlog){
+  
+    if (!isBearBlog(document)){
       return error(401, 'Origin is not registered with this server.')
     }
   }

--- a/src/routes/index/+server.js
+++ b/src/routes/index/+server.js
@@ -270,8 +270,16 @@ const handleHTML = async (response, s) => {
 const handler = async (s) => {
   let url = new URL(s)
   let isVerifiedOrigin = await verifiedOrigin(`${url.origin}/`)
+  let isBearBlog = document.head.querySelectorAll('meta').some(metaTag => metaTag.getAttribute('content') === 'look-for-the-bear-necessities')
   if (!isVerifiedOrigin) {
-    return error(401, 'Origin is not registered with this server.')
+    // adding as second level check so we still have the option to manually register
+    // which we might have to do in the case of white/blacklisting if anyone starts spoofing this check
+    // in any case, hard-coding this check into the main indexer is obvs not ideal and should be 
+    // generalized to an extendable from of altVerification
+    
+    if (!isBearBlog){
+      return error(401, 'Origin is not registered with this server.')
+    }
   }
 
   let isRecentlyIndexed = await recentlyIndexed(s)


### PR DESCRIPTION
- updates script object to reference existing script tag more specifically
- adds support for data-plugins on script tag
- hardcodes version of Herman's polyfill as linkfill option from data-plugins
- adds ~experimental~ option to create link tag if there is none. wonder if it works to actually send the fetch??
- test by adding data-plugins="linkfill" to the script tag, whether or not a preload link is present