### PR TITLE
RSS on API, blobjects

### DIFF
--- a/src/routes/get/[what]/[by]/[[as]]/+server.js
+++ b/src/routes/get/[what]/[by]/[[as]]/+server.js
@@ -3,6 +3,17 @@ import { load } from './load.js'
 
 export async function GET(req) {
   const response = await load(req)
+  
+  // Check if this is an RSS response
+  if (response.rss) {
+    return new Response(response.rss, {
+      headers: {
+        'Content-Type': 'application/rss+xml',
+        'Access-Control-Allow-Origin': '*'
+      }
+    })
+  }
+  
   return json(response, {
     headers: { 'Access-Control-Allow-Origin': '*' }
   })

--- a/src/routes/get/[what]/[by]/[[as]]/load.js
+++ b/src/routes/get/[what]/[by]/[[as]]/load.js
@@ -1,6 +1,7 @@
 import { queryBoolean, queryArray, buildEverythingQuery, buildSimpleQuery, buildThorpeQuery, buildDomainQuery } from '$lib/sparql.js'
 import { getBlobjectFromResponse, getMultiPassFromParams } from '$lib/converters.js'
 import { parseBindings } from '$lib/utils'
+import { rss } from '$lib/rssify.js'
 import { error, redirect, json } from '@sveltejs/kit';
 /*
 
@@ -84,6 +85,21 @@ export async function load({ params, url }) {
       query: query,
       actualResults: actualResults,
     }
+    case "rss":
+      // Create RSS feed structure
+      const rssTree = {
+        channel: {
+          title: multiPass.meta.title,
+          description: multiPass.meta.description,
+          link: url.href,
+          pubDate: new Date().toUTCString(),
+          items: actualResults
+        }
+      };
+      
+      return {
+        rss: rss(rssTree, params.what)
+      };
     default:
     return { results: actualResults }
     break


### PR DESCRIPTION
- updates rssify to parse blobjects
- adds generic `/rss` route for `[as]` in the API
- handles headers in server (good enough for now, more specific ones can be added in the future)

@nikolaswise sending this as a PR since it's mostly vibe-coded and changes in-use features. Attached examples of RSS from simple and blobject queries, which passed validation here: https://validator.w3.org/feed/check.cgi

Closes #90 

[rss-simple.txt](https://github.com/user-attachments/files/20895745/rss-simple.txt)
[rss-blobject.txt](https://github.com/user-attachments/files/20895746/rss-blobject.txt)
