### PR TITLE
Closes #64

### DIFF
--- a/src/lib/components/Footer.svelte
+++ b/src/lib/components/Footer.svelte
@@ -4,11 +4,11 @@
 <footer>
 	<nav>
   	<a href="/terms">Terms</a>
-  	<a href="/privacy">Privacy</a>
-    <a href="https://docs.octothorp.es/about/">About</a>
+    <a href="/about/">About</a>
     <a href="https://opencollective.com/stucco-software/projects/octothorpes/donate?interval=oneTime&amount=20&contributeAs=me">
       Support
     </a>
+   	<a href="/report">Report a Site</a>
 	</nav>
 
   <div class="center">
@@ -48,7 +48,7 @@
     text-decoration-skip-ink: auto;
     /*text-decoration: none;*/
     color: currentColor;
-  }  
+  }
   .center {
     display: grid;
     justify-content: center;

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -2,31 +2,24 @@
 <!-- directives:[] -->
 <div id="content"><h2 id="what-are-octothorpes">What are Octothorpes?</h2>
   <p>Octothorpes are hashtags and backlinks that can be used on regular websites, connecting pages across the open internet, regardless of where they're hosted.</p>
-  <p>A page that's tagged or hashtagged will show you the pages on a single domain with the same tag, but a page that's <em>octothorped</em> will show you the pages with the same tag across an unlimited number of domains.</p>
   <h4 id="what-does-“octothorpe”-actually-mean">What does “octothorpe” actually mean?</h4>
   <p>It's one of the <a href="https://demo.ideastore.dev/synonyms">many synonyms</a> for the number sign, or hashtag, with <a href="https://en.wikipedia.org/wiki/Number_sign#Octothorp">dubious origins</a>.</p>
   <h2 id="what-is-this-website">What is this website?</h2>
-  <p>Welcome to the first Octothorpe Protocol Web Ring!</p>
-  <p>This site is a hub that connects independent websites using the Octothorpe Protocol. So, sites that are registered with this Ring can use hashtags on their own pages, and other sites on this ring can see what they hashtagged, just as if they were on a shared platform like X or Instagram. The platform in this case is just the world wide web, and you don't have to give anyone your personal data to use it.</p>
-  <p>An Octothorpes Ring keeps track of info that registered sites have sent it, and gives them ways to use that info. It has a basic interface for browsing its <a href="https://octothorp.es/~">hashtags</a> and <a href="https://octothorp.es/domains">domains</a>, including <strong>RSS feeds for every hashtag</strong> so you can follow them as if you were on a platform.</p>
-  <p>If your site is on a Ring, you can embed octothorpes on your site, or use the API to build your own interface. Here's <a href="https://weirdweboctober-starter.glitch.me/sites/?octothorpe=weirdweboctober">an example</a> that lets you browse every topic that was part of <a href="https://octothorp.es/~/weirdweboctober">Weird Web October</a></p>
+  <p>Welcome to the first Octothorpe Protocol relay server!</p>
+  <p>This site is a hub that connects independent websites using the Octothorpe Protocol. So, sites that are registered with this OP server can use hashtags on their own pages, and other sites on this ring can see what they hashtagged, just as if they were on a shared platform like X or Instagram. The platform in this case is just the world wide web, and you don't have to give anyone your personal data to use it.</p>
+  <p>An OP server keeps track of info that registered sites have sent it, and gives them ways to use that info. It has a basic interface for browsing its <a href="https://octothorp.es/~">hashtags</a> and <a href="https://octothorp.es/domains">domains</a>, including <strong>RSS feeds for every hashtag</strong> so you can follow them as if you were on a platform.</p>
+
   <h2 id="what-is-the-octothorpe-protocol">What is the Octothorpe Protocol?</h2>
-  <p>If you just think of octothorpes as "hashtags for independent websites", that's great. But the system that lets you put a hashtag on your website can do <strong>so much</strong> more than that. The Octothorpes Protocol is what makes it work. It's basically a putting labels on webpages. </p>
-  <h2 id="why-would-i-want-to-put-labels-on-my-webpages">Why Would I Want to Put Labels on My Webpages?</h2>
-  <p>When you hashtag a page <code>#wombats</code>, the statement you make is "this page is associated with the term <code>wombats</code>." An Octothorpes Web Ring keeps track of those statements so that you can click on <code>#wombats</code> and see all the pages associated with that term. This gives you a way to find new sites and build communities or groups without relying on search engines or social platforms. We really liked what <a href="https://ribo.zone/">ribo.zone</a> said about <a href="https://ribo.zone/blog/weird-web-october-2024">using octothorpes to find new sites</a>, and we never would have known about it without octothorpes to follow.</p>
-  <h3 id="hashtags-are-just-one-kind-of-label">Hashtags are just one kind of label</h3>
-  <p>There's no reason we have to stick to hashtags. Say you read a thought-provoking blog post, and you wrote down the thoughts it provoked on your own blog, and you want to make a statement that "these two posts are related?"</p>
-  <p>That's what's called a <em>backlink</em> -- a link that goes both ways. You can link to a site, they can know you linked to them, and they can link back to you. There are a lot of different ways to do this on the internet. The Octothorpes Protocol has a special statement just for those, and, between sites that are using OP, it's as simple as making a regular link.</p>
-  <p>Find out more at the <a href="https://demo.ideastore.dev/backlinked-page">demo site.</a></p>
-  <p>Development is underway to add lots of other kinds of useful statments to the OP. You cacn check out our <a href="https://github.com/orgs/stucco-software/projects/3">public roadmap</a> to see what's happening.</p>
+  <p>If you just think of octothorpes as "hashtags for independent websites", that's great. But the system that lets you put a hashtag on your website can do <strong>so much</strong> more than that. The Octothorpe Protocol is what makes it work.</p>
+  <a href="http://docs.octothorp.es/about">Read the docs to find out more.</a>
+
   <h2 id="how-can-i-use-it">How Can I Use It?</h2>
   <p>There's no app or account to create -- all you have to do is paste a couple lines of HTML into your website. If you can do that, you can use octothorpes.</p>
-  <p>First step is to <a href="https://octothorp.es/register">register</a> your site here. Then check out the <a href="https://demo.ideastore.dev/quickstart">quickstart</a> page to, well, get started quickly.</p>
-  <p>If you want to get more in-depth, check out the <a href="https://octothorp.es/docs">documentation</a>.</p>
+  <p>First step is to <a href="https://octothorp.es/register">register</a> your site here. Then check out the <a href="https://docs.octothorp.es/quickstart">quickstart</a> page to, well, get started quickly.</p>
+  <p>If you want to get more in-depth, check out the <a href="https://docs.octothorp.es/about">documentation</a>.</p>
   <h2 id="why-did-you-make-this">Why Did You Make This?</h2>
   <p>Lots of reasons! We're collecting them here as we think of them: <a href="https://octothorp.es/~/why-we-made-octothorpes">why-we-made-octothorpes</a></p>
   <h2 id="id-prefer-a-nerdier-more-detailed-summary">I'd prefer a nerdier, more detailed summary</h2>
-  <p>Great. Here ya go:</p>
-  <p>Octothorpes is a lightweight protocol for creating hashtags and backlinks between websites across domains. The process is simple and platform independent. Register your domain with an octothorpe server, and you can send and receive information about hashtags used by any other domain on that server. "Octothorping" a webpage creates a relationship between the page's URL and the octothorped term on a server. All pages sharing terms and servers will be linked to each other just like posts with the same hashtags are linked on closed platforms like Instagram.</p>
-  <p>Servers are simple API hosts, and the network is intended to be distributed -- there's no limit to the number of servers a domain can interact with. Access can be controlled on a per-URI basis -- different pages on the same website can communicate with entirely different sets of servers. Communication between servers and pages happens over standard HTTP requests. Relationships are stored as RDF, and the core protocol includes the ability to create direct backlinks between URLs. The Octothorpes project provides basic client-side tools like drop-in scripts for easy adoption, and endpoints for platform-specific implementations. </p></div>
+  <p>Great. <a href="https://docs.octothorp.es/getting-started/">Here ya go.</a> </p>
+</div>
 </div>

--- a/src/routes/docs/+page.server.js
+++ b/src/routes/docs/+page.server.js
@@ -1,22 +1,5 @@
-import { getGraph, getFrame } from '$lib/ld/graph'
+import { redirect } from '@sveltejs/kit';
 
-export async function load({ params }){
-  const r = await getGraph()
-  let docTree = await getFrame({
-    id: "/docs",
-    body: {},
-    hasPart: {
-      prefLabel: {},
-      id: {},
-      type: {},
-      body: {},
-      draft: {},
-      hasPart: {
-        prefLabel: {},
-        draft: {},
-        body: {}
-      }
-    }
-  })
-  return docTree
+export function load() {
+  redirect(307, 'https://docs.octothorp.es')
 }

--- a/src/routes/~/[thorpe]/+page.svelte
+++ b/src/routes/~/[thorpe]/+page.svelte
@@ -5,7 +5,10 @@
 
 <main class="container">
   <h1>#{data.term}</h1>
-
+ <div id="follow-links">
+     <p class="narrow gray" id="follow-links"> <a href="/get/pages/thorped/rss?o={data.term}" id="rss-link"><img src="/Rss_Shiny_Icon.svg" alt="RSS feed link" width="20" style="display: inline;"> RSS</a> • <a href="/get/pages/thorped?o={data.term}" id="json-link">JSON</a>
+     </p>
+ </div>
   <ul>
     {#each data.thorpes as thorpe}
       <li>
@@ -49,24 +52,14 @@
     {/each}
   </ul>
 
-  <p>
-    Follow <code>#{data.term}</code> on <a href="/~/{encodeURIComponent(data.term)}/rss">RSS</a> or use the
-    <details>
-      <summary>
-        <code>JSON API</code>
-      </summary>
-      <pre><code>
-curl -X GET \
-  -H "Content-type: application/json" \
-  -H "Accept: application/json" \
-  "https://octothorp.es/~/{encodeURIComponent(data.term)}"
-      </code></pre>
-  </details>
-  </p>
+
 
 </main>
 
 <style type="text/css">
+    h1 {
+        margin-bottom: .2rem;
+    }
   ul {
     margin-block: var(--lead-4);
   }
@@ -86,4 +79,13 @@ curl -X GET \
     color: var(--dark-gray);
     font-size: .8rem;
   }
+  #follow-links {
+      width: 100%;
+      display: inline-block;
+      font-family: monospace;
+  }
+    #follow-links a {
+        text-decoration: none;
+    }
+
 </style>

--- a/static/Rss_Shiny_Icon.svg
+++ b/static/Rss_Shiny_Icon.svg
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 15.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1"
+	 id="svg2" sodipodi:version="0.32" inkscape:version="0.47 r22583" inkscape:output_extension="org.inkscape.output.svg.inkscape" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:svg="http://www.w3.org/2000/svg" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" sodipodi:docname="rss-feed.svg"
+	 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="256px" height="256px"
+	 viewBox="0 0 256 256" enable-background="new 0 0 256 256" xml:space="preserve">
+<path fill="#E15A00" d="M9.496,210.008c0,19.6,15.888,35.486,35.486,35.486h164.034c19.604,0,35.487-15.889,37.487-34.82
+	l-0.001-164.013c-1.999-20.266-17.888-36.155-37.484-36.155H44.982c-19.599,0-35.486,15.889-35.486,35.487V210.008z"/>
+<g id="layer1" transform="translate(-373.642,-318.344)" inkscape:groupmode="layer" inkscape:label="Layer 1">
+	
+		<path id="path5270" sodipodi:cy="200.64285" sodipodi:type="arc" sodipodi:cx="360.35715" sodipodi:rx="24.642859" sodipodi:ry="23.928572" fill="#FFFFFF" d="
+		M469.09,505.078c0,11.498-9.598,20.817-21.438,20.817c-11.84,0-21.438-9.319-21.438-20.817c0-11.496,9.599-20.816,21.438-20.816
+		C459.491,484.262,469.09,493.582,469.09,505.078z"/>
+	<path id="path5805" sodipodi:nodetypes="ccccc" fill="#FFFFFF" d="M426.835,455.057l-0.073-30.273
+		c64.706,3.375,100.618,49.674,101.5,101.939h-30.318C497.441,480.781,466.204,456.728,426.835,455.057z"/>
+	<path id="path5807" sodipodi:nodetypes="ccccc" fill="#FFFFFF" d="M427.202,404.572l-0.879-30.758
+		c99.428,4.616,152.676,76.769,153.348,152.909l-31.197-0.439C549.839,477.58,513.808,406.017,427.202,404.572z"/>
+</g>
+<g>
+	
+		<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="102.5" y1="-491.002" x2="102.5" y2="-598.5135" gradientTransform="matrix(1 0 0 -1 25.5 -353)">
+		<stop  offset="0" style="stop-color:#000000;stop-opacity:0.15"/>
+		<stop  offset="0.6626" style="stop-color:#000000;stop-opacity:0"/>
+	</linearGradient>
+	<path fill="url(#SVGID_1_)" d="M9.496,115.402v94.606c0,19.6,15.888,35.486,35.487,35.486h164.033
+		c19.604,0,35.488-15.889,37.488-34.82v-95.952c-36.779,15.182-77.074,23.577-119.337,23.577
+		C85.542,138.299,45.825,130.154,9.496,115.402z"/>
+</g>
+<linearGradient id="SVGID_2_" gradientUnits="userSpaceOnUse" x1="102.4995" y1="-364.168" x2="102.4995" y2="-491.7969" gradientTransform="matrix(1 0 0 -1 25.5 -353)">
+	<stop  offset="0" style="stop-color:#FFFFFF;stop-opacity:0.85"/>
+	<stop  offset="0.66" style="stop-color:#FFFFFF;stop-opacity:0"/>
+</linearGradient>
+<path fill="url(#SVGID_2_)" d="M209.018,10.505H44.983c-19.599,0-35.487,15.889-35.487,35.487v69.409
+	c36.33,14.751,76.046,22.897,117.671,22.897c42.263,0,82.558-8.396,119.336-23.577v-68.06
+	C244.504,26.395,228.615,10.505,209.018,10.505z"/>
+<path fill="none" stroke="#E15A00" stroke-width="2" stroke-miterlimit="10" d="M246.503,114.721V46.66
+	c-1.999-20.266-17.888-36.155-37.485-36.155H44.982c-19.599,0-35.486,15.889-35.486,35.487v69.409"/>
+<g>
+	<g>
+		<g>
+			<path fill="none" stroke="#B34700" stroke-width="2" stroke-miterlimit="10" d="M9.496,115.401v94.605
+				c0,19.6,15.888,35.486,35.486,35.486h164.034c19.604,0,35.487-15.889,37.487-34.819v-95.952"/>
+		</g>
+	</g>
+</g>
+</svg>


### PR DESCRIPTION
- moves RSS and JSON links to top of hashtag pages
- updates /about to be more about this server and point out to docs for basics
- redirects docs out
- replaces nonexistent privacy link with report