### PR TITLE
feat: Phase 3 enrichment for blobject target metadata

### DIFF
--- a/src/lib/sparql.js
+++ b/src/lib/sparql.js
@@ -54,6 +54,83 @@ export const queryArray = async query => {
 }
 
 /**
+ * Enriches blobjects by fetching backlink metadata (subtype and terms) for page-type targets.
+ * Phase 3 query: for each source->target pair, looks up blank node data on the target side.
+ * @param {Array} blobjects - Array of blobject objects from getBlobjectFromResponse
+ * @returns {Promise<Array>} The same blobjects array with enriched octothorpe entries
+ */
+export const enrichBlobjectTargets = async (blobjects) => {
+  const sourceUris = new Set()
+  const targetUris = new Set()
+
+  for (const blob of blobjects) {
+    sourceUris.add(blob['@id'])
+    for (const o of blob.octothorpes) {
+      if (typeof o === 'object' && o.uri) {
+        targetUris.add(o.uri)
+      }
+    }
+  }
+
+  if (targetUris.size === 0) return blobjects
+
+  const sourceValues = [...sourceUris].map(u => `<${u}>`).join(' ')
+  const targetValues = [...targetUris].map(u => `<${u}>`).join(' ')
+
+  const response = await queryArray(`
+    SELECT ?source ?target ?bnType ?term WHERE {
+      VALUES ?source { ${sourceValues} }
+      VALUES ?target { ${targetValues} }
+      ?target octo:octothorpes ?bn .
+      ?bn octo:url ?source .
+      ?bn rdf:type ?bnType .
+      OPTIONAL { ?bn octo:octothorpes ?term . }
+    }
+  `)
+
+  // Build lookup: "source|target" -> { type, terms[] }
+  const lookup = new Map()
+  for (const binding of response.results.bindings) {
+    const source = binding.source.value
+    const target = binding.target.value
+    const key = `${source}|${target}`
+    let bnType = binding.bnType?.value || ''
+    if (bnType.startsWith('octo:')) bnType = bnType.substring(5)
+
+    if (!lookup.has(key)) {
+      lookup.set(key, { type: bnType, terms: [] })
+    }
+    const entry = lookup.get(key)
+    if (bnType && bnType !== 'Backlink' && entry.type === 'Backlink') {
+      entry.type = bnType
+    }
+
+    if (binding.term?.value) {
+      const termUri = binding.term.value
+      const termName = termUri.substring(termUri.lastIndexOf('~/') + 2)
+      if (!entry.terms.includes(termName)) {
+        entry.terms.push(termName)
+      }
+    }
+  }
+
+  // Merge back into blobjects
+  for (const blob of blobjects) {
+    for (const o of blob.octothorpes) {
+      if (typeof o === 'object' && o.uri) {
+        const meta = lookup.get(`${blob['@id']}|${o.uri}`)
+        if (meta) {
+          o.type = meta.type
+          if (meta.terms.length > 0) o.terms = meta.terms
+        }
+      }
+    }
+  }
+
+  return blobjects
+}
+
+/**
  * Executes a SPARQL ASK query and returns a boolean result
  * @param {string} query - The SPARQL ASK query to execute
  * @returns {Promise<boolean>} Promise resolving to the boolean result of the ASK query

--- a/src/routes/get/[what]/[by]/[[as]]/load.js
+++ b/src/routes/get/[what]/[by]/[[as]]/load.js
@@ -1,4 +1,4 @@
-import { queryBoolean, queryArray, buildEverythingQuery, buildSimpleQuery, buildThorpeQuery, buildDomainQuery } from '$lib/sparql.js'
+import { queryBoolean, queryArray, buildEverythingQuery, buildSimpleQuery, buildThorpeQuery, buildDomainQuery, enrichBlobjectTargets } from '$lib/sparql.js'
 import { getBlobjectFromResponse, getMultiPassFromParams } from '$lib/converters.js'
 import { parseBindings } from '$lib/utils'
 import { rss } from '$lib/rssify.js'
@@ -52,6 +52,7 @@ export async function load({ params, url }) {
       // Pass filters when returning blobjects, because blobjects are composite objects
       // and we want to filter the set of blobjects, not response entries
       actualResults = await getBlobjectFromResponse(bj, multiPass.filters);
+      actualResults = await enrichBlobjectTargets(actualResults);
       // TKTK check to run filters on result instead of query
       break;
     case "thorpes":

--- a/src/routes/query/+page.server.js
+++ b/src/routes/query/+page.server.js
@@ -1,4 +1,4 @@
-import { queryArray, buildEverythingQuery, buildSimpleQuery, buildThorpeQuery, buildDomainQuery } from '$lib/sparql.js'
+import { queryArray, buildEverythingQuery, buildSimpleQuery, buildThorpeQuery, buildDomainQuery, enrichBlobjectTargets } from '$lib/sparql.js'
 import { getBlobjectFromResponse } from '$lib/converters.js'
 import { parseBindings } from '$lib/utils'
 
@@ -29,6 +29,7 @@ export const actions = {
           query = await buildEverythingQuery(multiPass)
           const bj = await queryArray(query)
           actualResults = await getBlobjectFromResponse(bj, multiPass.filters)
+          actualResults = await enrichBlobjectTargets(actualResults)
           break
 
         case "thorpes":

--- a/src/tests/enrich.test.js
+++ b/src/tests/enrich.test.js
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { enrichBlobjectTargets } from '$lib/sparql.js'
+
+// Mock fetch globally to intercept SPARQL queries
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+function sparqlResponse(bindings) {
+  return {
+    ok: true,
+    json: () => Promise.resolve({ results: { bindings } })
+  }
+}
+
+beforeEach(() => {
+  mockFetch.mockReset()
+})
+
+describe('enrichBlobjectTargets', () => {
+  it('returns empty array unchanged', async () => {
+    const result = await enrichBlobjectTargets([])
+    expect(result).toEqual([])
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('skips query when no page-type octothorpes exist', async () => {
+    const blobjects = [{
+      '@id': 'http://example.com/page',
+      title: 'Page',
+      description: null,
+      image: null,
+      date: 1700000000,
+      octothorpes: ['gadgets', 'bikes']
+    }]
+    const result = await enrichBlobjectTargets(blobjects)
+    expect(result).toEqual(blobjects)
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('merges subtype onto octothorpe objects', async () => {
+    mockFetch.mockResolvedValueOnce(sparqlResponse([{
+      source: { value: 'http://source.com/page' },
+      target: { value: 'http://target.com/linked' },
+      bnType: { value: 'octo:Bookmark' }
+    }]))
+
+    const blobjects = [{
+      '@id': 'http://source.com/page',
+      title: 'Source',
+      description: null,
+      image: null,
+      date: 1700000000,
+      octothorpes: [
+        'gadgets',
+        { uri: 'http://target.com/linked', type: 'link' }
+      ]
+    }]
+
+    const result = await enrichBlobjectTargets(blobjects)
+    const pageOcto = result[0].octothorpes.find(o => typeof o === 'object')
+    expect(pageOcto.type).toBe('Bookmark')
+  })
+
+  it('merges terms array onto octothorpe objects', async () => {
+    mockFetch.mockResolvedValueOnce(sparqlResponse([
+      {
+        source: { value: 'http://source.com/page' },
+        target: { value: 'http://target.com/linked' },
+        bnType: { value: 'octo:Bookmark' },
+        term: { value: 'https://octothorp.es/~/gadgets' }
+      },
+      {
+        source: { value: 'http://source.com/page' },
+        target: { value: 'http://target.com/linked' },
+        bnType: { value: 'octo:Bookmark' },
+        term: { value: 'https://octothorp.es/~/bikes' }
+      }
+    ]))
+
+    const blobjects = [{
+      '@id': 'http://source.com/page',
+      title: 'Source',
+      description: null,
+      image: null,
+      date: 1700000000,
+      octothorpes: [
+        { uri: 'http://target.com/linked', type: 'link' }
+      ]
+    }]
+
+    const result = await enrichBlobjectTargets(blobjects)
+    const pageOcto = result[0].octothorpes[0]
+    expect(pageOcto.type).toBe('Bookmark')
+    expect(pageOcto.terms).toContain('gadgets')
+    expect(pageOcto.terms).toContain('bikes')
+  })
+
+  it('handles mixed blobjects (some with targets, some without)', async () => {
+    mockFetch.mockResolvedValueOnce(sparqlResponse([{
+      source: { value: 'http://source.com/page1' },
+      target: { value: 'http://target.com/linked' },
+      bnType: { value: 'octo:Cite' },
+      term: { value: 'https://octothorp.es/~/research' }
+    }]))
+
+    const blobjects = [
+      {
+        '@id': 'http://source.com/page1',
+        title: 'Page with links',
+        description: null,
+        image: null,
+        date: 1700000000,
+        octothorpes: [
+          'tag1',
+          { uri: 'http://target.com/linked', type: 'link' }
+        ]
+      },
+      {
+        '@id': 'http://source.com/page2',
+        title: 'Page with only terms',
+        description: null,
+        image: null,
+        date: 1700000001,
+        octothorpes: ['tag2', 'tag3']
+      }
+    ]
+
+    const result = await enrichBlobjectTargets(blobjects)
+
+    const enrichedOcto = result[0].octothorpes.find(o => typeof o === 'object')
+    expect(enrichedOcto.type).toBe('Cite')
+    expect(enrichedOcto.terms).toContain('research')
+
+    expect(result[1].octothorpes).toEqual(['tag2', 'tag3'])
+  })
+
+  it('prefers specific subtype over Backlink', async () => {
+    mockFetch.mockResolvedValueOnce(sparqlResponse([
+      {
+        source: { value: 'http://source.com/page' },
+        target: { value: 'http://target.com/linked' },
+        bnType: { value: 'octo:Backlink' }
+      },
+      {
+        source: { value: 'http://source.com/page' },
+        target: { value: 'http://target.com/linked' },
+        bnType: { value: 'octo:Bookmark' }
+      }
+    ]))
+
+    const blobjects = [{
+      '@id': 'http://source.com/page',
+      title: 'Source',
+      description: null,
+      image: null,
+      date: 1700000000,
+      octothorpes: [
+        { uri: 'http://target.com/linked', type: 'link' }
+      ]
+    }]
+
+    const result = await enrichBlobjectTargets(blobjects)
+    expect(result[0].octothorpes[0].type).toBe('Bookmark')
+  })
+
+  it('does not add terms array when no terms exist', async () => {
+    mockFetch.mockResolvedValueOnce(sparqlResponse([{
+      source: { value: 'http://source.com/page' },
+      target: { value: 'http://target.com/linked' },
+      bnType: { value: 'octo:Bookmark' }
+    }]))
+
+    const blobjects = [{
+      '@id': 'http://source.com/page',
+      title: 'Source',
+      description: null,
+      image: null,
+      date: 1700000000,
+      octothorpes: [
+        { uri: 'http://target.com/linked', type: 'link' }
+      ]
+    }]
+
+    const result = await enrichBlobjectTargets(blobjects)
+    expect(result[0].octothorpes[0].terms).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `enrichBlobjectTargets()` in `sparql.js` -- a Phase 3 SPARQL query that fetches backlink blank node metadata (subtype + terms) for page-type octothorpe targets
- Merges Bookmark/Cite types and relationship terms onto octothorpe objects that previously only showed `type: "link"`
- Called after `getBlobjectFromResponse` in both `load.js` and `query/+page.server.js`

## Test Plan

- [x] 7 unit tests covering empty arrays, term-only blobjects, subtype merging, terms merging, mixed blobjects, subtype precedence, and no-terms case
- [x] Full suite passes (240 tests)
- [x] Manual verification: re-index a page with bookmarks/cites, query `/get/everything/thorped`, confirm enriched types and terms